### PR TITLE
Replace git.apache.org

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,3 +64,5 @@ require (
 	honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3 // indirect
 	k8s.io/kubernetes v1.6.1 // indirect
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/Azure/go-autorest v11.3.2+incompatible h1:2bRmoaLvtIXW5uWpZVoIkc0C1z7
 github.com/Azure/go-autorest v11.3.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apparentlymart/go-cidr v0.0.0-20170418151526-7e4b007599d4 h1:bpmA3CCh0K829XIR5kfcV+YDt+Gwi7SEYPCcYEVKWUo=
 github.com/apparentlymart/go-cidr v0.0.0-20170418151526-7e4b007599d4/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-rundeck-api v0.0.0-20160826143032-f6af74d34d1e/go.mod h1:U6OjNHcY3edY04ILn+KNrWZm3j15cPzW7PyjtIQOh1Y=


### PR DESCRIPTION
# WHY
git.apache.org is down and terraform won't build without it

# WHAT
Replace git.apache.org with a github URL