### PR TITLE
Remove routing_weight validation function

### DIFF
--- a/azurerm/resource_arm_virtual_network_gateway_connection.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection.go
@@ -99,7 +99,6 @@ func resourceArmVirtualNetworkGatewayConnection() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
 			"shared_key": {


### PR DESCRIPTION
**What**
- Remove routing_weight validation function

*Why**
- Allows performing drift detection where API returns "0" in the event the prop is not set