### PR TITLE
[RM-2806] Make location optional for network interface

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -35,7 +35,7 @@ func resourceArmNetworkInterface() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"location": locationSchema(),
+			"location": locationSchemaOptional(),
 
 			"resource_group_name": resourceGroupNameSchema(),
 


### PR DESCRIPTION
# WHY

Inconsistencies when fetching certain network interfaces where location is empty