### PR TITLE
[RM-3243] Subnet Service Delegation ValidationFunc Case Insensitivity

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -85,17 +85,19 @@ func resourceArmSubnet() *schema.Resource {
 									"name": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"Microsoft.Batch/batchAccounts",
-											"Microsoft.ContainerInstance/containerGroups",
-											"Microsoft.HardwareSecurityModules/dedicatedHSMs",
-											"Microsoft.Logic/integrationServiceEnvironments",
-											"Microsoft.Netapp/volumes",
-											"Microsoft.ServiceFabricMesh/networks",
-											"Microsoft.Sql/managedInstances",
-											"Microsoft.Sql/servers",
-											"Microsoft.Web/serverFarms",
-										}, false),
+										// Removing this validation because of issues related to case sensitivity
+										// See https://luminal.atlassian.net/browse/RM-3243
+										// ValidateFunc: validation.StringInSlice([]string{
+										// 	"Microsoft.Batch/batchAccounts",
+										// 	"Microsoft.ContainerInstance/containerGroups",
+										// 	"Microsoft.HardwareSecurityModules/dedicatedHSMs",
+										// 	"Microsoft.Logic/integrationServiceEnvironments",
+										// 	"Microsoft.Netapp/volumes",
+										// 	"Microsoft.ServiceFabricMesh/networks",
+										// 	"Microsoft.Sql/managedInstances",
+										// 	"Microsoft.Sql/servers",
+										// 	"Microsoft.Web/serverFarms",
+										// }, false),
 									},
 									"actions": {
 										Type:     schema.TypeList,


### PR DESCRIPTION
## What

A prospective customer experienced an issue in which the survey was returning a tfstate file with `Microsoft.Web/serverFarms` and `Microsoft.Web/serverfarms` for the subnet server delegation value.  The validation function for this resource does not allow the lowercase version and so `plan` errored.  

This seems to be some sort of strange inconsistency in the Azure RM API, so we are just going to remove the validation on this value because we don't need to validate this in any event.

## JIRA
https://luminal.atlassian.net/browse/RM-3243