### PR TITLE
[RM-3685] Repeat drift notifications on an Azure environment

### DIFF
--- a/azurerm/internal/services/network/resource_arm_subnet.go
+++ b/azurerm/internal/services/network/resource_arm_subnet.go
@@ -126,8 +126,7 @@ func resourceArmSubnet() *schema.Resource {
 
 			"enforce_private_link_endpoint_network_policies": {
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 
 			"enforce_private_link_service_network_policies": {

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -392,12 +392,20 @@ func resourceArmStorageAccount() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
+				// Ignore the drift: static_website.#: "1" => "0"
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "1" && new == "0" {
+						return true
+					}
+					return false
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"index_document": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:     schema.TypeString,
+							Optional: true,
+							// ValidateFunc: validation.StringIsNotEmpty,
+							Default: "index.html",
 						},
 						"error_404_document": {
 							Type:         schema.TypeString,


### PR DESCRIPTION
Before:

```
terraform plan -no-color -refresh=false -state=terraform.tfstate -out=terraform.plan

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

~ azurerm_storage_account.L3N1YnNjcmlwdGlvbnMvNWVkNTM3YjUtYTZlYS00YzBkLTljNGItMDY2MTg3Mjk5ZWY3L3Jlc291cmNlR3JvdXBzLzRURUxML3Byb3ZpZGVycy9NaWNyb3NvZnQuU3RvcmFnZS9zdG9yYWdlQWNjb3VudHMvbG9uZ3Rlcm1maWxlc3RvcmFnZQ
      static_website.#:                               "1" => "0"
      static_website.0.index_document:                "index.html" => ""

  ~ azurerm_subnet.L3N1YnNjcmlwdGlvbnMvNWVkNTM3YjUtYTZlYS00YzBkLTljNGItMDY2MTg3Mjk5ZWY3L3Jlc291cmNlR3JvdXBzLzRURUxML3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay92aXJ0dWFsTmV0d29ya3MvNFRFTEwtQVpVUkUxL3N1Ym5ldHMvZGVmYXVsdA
      enforce_private_link_endpoint_network_policies: "true" => "false"
Plan: 0 to add, 2 to change, 0 to destroy.

------------------------------------------------------------------------

This plan was saved to: terraform.plan
```

After:
```
$ terraform plan -refresh=false

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```