### PR TITLE
[RM-3780] Toggle output logging

### DIFF
--- a/azurerm/init.go
+++ b/azurerm/init.go
@@ -1,0 +1,15 @@
+package aws
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func init() {
+	// Disable logging unless debugging, otherwise resource configuration is written to the logs
+	val, ok := os.LookupEnv("TF_LOG")
+	if !ok || val == "" {
+		log.SetOutput(ioutil.Discard)
+	}
+}


### PR DESCRIPTION
## What

Adds an init function which will honor `TF_LOG` according to the [docs](https://www.terraform.io/docs/commands/environment-variables.html). Logs are simply log.Printf() statements which don't honor any log level setting. 

## Why

Every survey of customer accounts results in their resource configuration being logged to Cloudwatch Logs.

## Concerns

This file needs to be maintained going forward when upgrading providers. It's in a separate file so there should be no merging required. 