### PR TITLE
[RM-3983] Cancel Azure Snapshot Naming Validation

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_snapshot.go
+++ b/azurerm/internal/services/compute/resource_arm_snapshot.go
@@ -38,10 +38,10 @@ func resourceArmSnapshot() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: ValidateSnapshotName,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				// ValidateFunc: ValidateSnapshotName,
 			},
 
 			"location": azure.SchemaLocation(),


### PR DESCRIPTION
## What

Azure Snapshot naming now allows a period, but the validation function does not allow this.  Instead of incrementally adding characters to the validation function whenever a scan fails on Azure allowing new characters, we are just going to disable the naming validation.

## JIRA

https://luminal.atlassian.net/browse/RM-3983