### PR TITLE
[RM-3945] Allow Zero for CORS Rule Max Age

### DIFF
--- a/azurerm/helpers/azure/storage_account.go
+++ b/azurerm/helpers/azure/storage_account.go
@@ -58,7 +58,7 @@ func SchemaStorageAccountCorsRule() *schema.Schema {
 				"max_age_in_seconds": {
 					Type:         schema.TypeInt,
 					Required:     true,
-					ValidateFunc: validation.IntBetween(1, 2000000000),
+					ValidateFunc: validation.IntBetween(0, 2000000000),
 				},
 			},
 		},


### PR DESCRIPTION
## What

When defining a CORS rule for a storage account, the default value for Max Age in Seconds is 0.  This value is not accepted by the validator for this field.  This PR fixes that.