### PR TITLE
Azure Monitor Activity Log Alert Level Case Insensitive Validation

### DIFF
--- a/azurerm/internal/services/monitor/resource_arm_monitor_activity_log_alert.go
+++ b/azurerm/internal/services/monitor/resource_arm_monitor_activity_log_alert.go
@@ -96,7 +96,7 @@ func resourceArmMonitorActivityLogAlert() *schema.Resource {
 								"Warning",
 								"Error",
 								"Critical",
-							}, false),
+							}, true),
 						},
 						"resource_provider": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
`azurerm_monitor_activity_log_alert` has a validation for its severity level which expects Title Case but the API returns lower case.  This PR changes the validation to be case insensitive.