### PR TITLE
Add CongifurationSet Resource Type

### DIFF
--- a/azurerm/internal/services/mysql/registration.go
+++ b/azurerm/internal/services/mysql/registration.go
@@ -27,6 +27,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azurerm_mysql_configuration":        resourceArmMySQLConfiguration(),
+		"azurerm_mysql_configuration_set":    resourceArmMySQLConfigurationSet(),
 		"azurerm_mysql_database":             resourceArmMySqlDatabase(),
 		"azurerm_mysql_firewall_rule":        resourceArmMySqlFirewallRule(),
 		"azurerm_mysql_server":               resourceArmMySqlServer(),

--- a/azurerm/internal/services/mysql/resource_arm_mysql_configuration_set.go
+++ b/azurerm/internal/services/mysql/resource_arm_mysql_configuration_set.go
@@ -1,3 +1,6 @@
+// This is a Fugue internal resource type.  
+// It aggregates the values from individual Configuration resources into one map.
+
 package mysql
 
 import (

--- a/azurerm/internal/services/mysql/resource_arm_mysql_configuration_set.go
+++ b/azurerm/internal/services/mysql/resource_arm_mysql_configuration_set.go
@@ -1,0 +1,96 @@
+package mysql
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmMySQLConfigurationSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmMySQLConfigurationSetCreate,
+		Read:   resourceArmMySQLConfigurationSetRead,
+		Delete: resourceArmMySQLConfigurationSetDelete,
+		Update: resourceArmMySQLConfigurationSetCreate,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"config_map": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Required: true,
+				ForceNew: false,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"server_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateMySqlServerName,
+			},
+		},
+	}
+}
+
+func resourceArmMySQLConfigurationSetCreate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceArmMySQLConfigurationSetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MySQL.ConfigurationsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serverName := id.Path["servers"]
+	resp, err := client.ListByServer(ctx, resourceGroup, serverName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[WARN] MySQL Server %q was not found (resource group %q)", serverName, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making List Configuration request on Azure MySQL Server %q (Resource Group %q): %+v", serverName, resourceGroup, err)
+	}
+	configMap := make(map[string]interface{})
+	configs := resp.Value
+	for _, conf := range *configs {
+		key := conf.Name
+		value := conf.ConfigurationProperties.Value
+		configMap[*key] = *value
+	}
+	d.Set("server_name", serverName)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("config_map", configMap)
+
+	return nil
+}
+
+func resourceArmMySQLConfigurationSetDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/azurerm/internal/services/postgres/registration.go
+++ b/azurerm/internal/services/postgres/registration.go
@@ -29,6 +29,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azurerm_postgresql_configuration":        resourceArmPostgreSQLConfiguration(),
+		"azurerm_postgresql_configuration_set":    resourceArmPostgreSQLConfigurationSet(),
 		"azurerm_postgresql_database":             resourceArmPostgreSQLDatabase(),
 		"azurerm_postgresql_firewall_rule":        resourceArmPostgreSQLFirewallRule(),
 		"azurerm_postgresql_server":               resourceArmPostgreSQLServer(),

--- a/azurerm/internal/services/postgres/resource_arm_postgresql_configuration_set.go
+++ b/azurerm/internal/services/postgres/resource_arm_postgresql_configuration_set.go
@@ -1,0 +1,96 @@
+package postgres
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmPostgreSQLConfigurationSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmPostgreSQLConfigurationSetCreate,
+		Read:   resourceArmPostgreSQLConfigurationSetRead,
+		Delete: resourceArmPostgreSQLConfigurationSetDelete,
+		Update: resourceArmPostgreSQLConfigurationSetCreate,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"config_map": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Required: true,
+				ForceNew: false,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"server_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: ValidatePSQLServerName,
+			},
+		},
+	}
+}
+
+func resourceArmPostgreSQLConfigurationSetCreate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceArmPostgreSQLConfigurationSetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Postgres.ConfigurationsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serverName := id.Path["servers"]
+	resp, err := client.ListByServer(ctx, resourceGroup, serverName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[WARN] PostgreSQL Server %q was not found (resource group %q)", serverName, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making List Configuration request on Azure PostgreSQL Server %q (Resource Group %q): %+v", serverName, resourceGroup, err)
+	}
+	configMap := make(map[string]interface{})
+	configs := resp.Value
+	for _, conf := range *configs {
+		key := conf.Name
+		value := conf.ConfigurationProperties.Value
+		configMap[*key] = *value
+	}
+	d.Set("server_name", serverName)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("config_map", configMap)
+
+	return nil
+}
+
+func resourceArmPostgreSQLConfigurationSetDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/azurerm/internal/services/postgres/resource_arm_postgresql_configuration_set.go
+++ b/azurerm/internal/services/postgres/resource_arm_postgresql_configuration_set.go
@@ -1,3 +1,6 @@
+// This is a Fugue internal resource type.
+// It aggregates the values from individual Configuration resources into one map.
+
 package postgres
 
 import (


### PR DESCRIPTION
This PR adds two new resource types, `azurerm_mysql_configuration_set` and `azurerm_postgresql_configuration_set`, which are aggregates of the values of the individual `azurerm_mysql/postgresql_configuration` resources.