### PR TITLE
[RM-4524] Prevent panic on nil address_prefix

### DIFF
--- a/azurerm/internal/services/network/resource_arm_virtual_network.go
+++ b/azurerm/internal/services/network/resource_arm_virtual_network.go
@@ -434,7 +434,9 @@ func resourceAzureSubnetHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		buf.WriteString(m["name"].(string))
-		buf.WriteString(m["address_prefix"].(string))
+		if v, ok := m["address_prefix"]; ok {
+			buf.WriteString(v.(string))
+		}
 
 		if v, ok := m["security_group"]; ok {
 			buf.WriteString(v.(string))


### PR DESCRIPTION
Subnets with both IPv4 and IPv6 address prefixes will have a nil `address_prefix` property. This PR resolves the panic, but does not add support for multiple address prefixes.