### PR TITLE
Panic on VMSS Nil Pointer

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
@@ -1260,8 +1260,8 @@ func flattenAzureRmVirtualMachineScaleSetOsProfileSecrets(secrets *[]compute.Vau
 
 func flattenAzureRmVirtualMachineScaleSetBootDiagnostics(bootDiagnostic *compute.BootDiagnostics) []interface{} {
 	b := map[string]interface{}{
-		"enabled":     *bootDiagnostic.Enabled,
-		"storage_uri": *bootDiagnostic.StorageURI,
+		"enabled":     utils.BoolValue(bootDiagnostic.Enabled),
+		"storage_uri": utils.StringValue(bootDiagnostic.StorageURI),
 	}
 
 	return []interface{}{b}

--- a/azurerm/utils/pointer.go
+++ b/azurerm/utils/pointer.go
@@ -4,6 +4,15 @@ func Bool(input bool) *bool {
 	return &input
 }
 
+// BoolValue returns the value of the bool pointer passed in or
+// false if the pointer is nil.
+func BoolValue(v *bool) bool {
+	if v != nil {
+		return *v
+	}
+	return false
+}
+
 func Int(input int) *int {
 	return &input
 }
@@ -22,4 +31,13 @@ func Float(input float64) *float64 {
 
 func String(input string) *string {
 	return &input
+}
+
+// StringValue returns the value of the string pointer passed in or
+// "" if the pointer is nil.
+func StringValue(v *string) string {
+	if v != nil {
+		return *v
+	}
+	return ""
 }


### PR DESCRIPTION
## What

Adds two helper functions (copied from the AWS provider) that safely dereference pointer values by checking for `nil` first and uses those helper functions to avoid a panic when getting the values for VMSS boot diagnostics.

## Why

In Virtual Machine Scaling Sets, the Storage URI for the Boot Diagnostics setting can be blank (verified with `az vmss update --name foo --resource-group bar --set virtualMachineProfile.diagnosticsProfile="{\"bootDiagnostics\": {\"Enabled\": \"True\",\"StorageUri\":\"\"}}"`).  

The flattening function for the diagnostic values dereferences a pointer to the string value without checking if it is `nil` first.  