### PR TITLE
Remove Admin Creds from Container Registry

### DIFF
--- a/azurerm/internal/services/containers/resource_arm_container_registry.go
+++ b/azurerm/internal/services/containers/resource_arm_container_registry.go
@@ -93,16 +93,17 @@ func resourceArmContainerRegistry() *schema.Resource {
 				Computed: true,
 			},
 
-			"admin_username": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+			// We do not want any admin creds in our statefiles
+			// "admin_username": {
+			// 	Type:     schema.TypeString,
+			// 	Computed: true,
+			// },
 
-			"admin_password": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
+			// "admin_password": {
+			// 	Type:      schema.TypeString,
+			// 	Computed:  true,
+			// 	Sensitive: true,
+			// },
 
 			"network_rule_set": {
 				Type:       schema.TypeList,
@@ -513,11 +514,8 @@ func resourceArmContainerRegistryRead(d *schema.ResourceData, meta interface{}) 
 	// 		break
 	// 	}
 	// } else {
-
-	// We do not want passwords in our statefiles and this api call requires more permissions than the Reader role grants
-	d.Set("admin_username", "")
-	d.Set("admin_password", "")
-
+	// 		d.Set("admin_username", "")
+	// 		d.Set("admin_password", "")
 	// }
 
 	replications, err := replicationClient.List(ctx, resourceGroup, name)

--- a/azurerm/internal/services/containers/resource_arm_container_registry.go
+++ b/azurerm/internal/services/containers/resource_arm_container_registry.go
@@ -501,21 +501,24 @@ func resourceArmContainerRegistryRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("storage_account_id", account.ID)
 	}
 
-	if *resp.AdminUserEnabled {
-		credsResp, errList := client.ListCredentials(ctx, resourceGroup, name)
-		if errList != nil {
-			return fmt.Errorf("Error making Read request on Azure Container Registry %s for Credentials: %s", name, errList)
-		}
+	// if *resp.AdminUserEnabled {
+	// 	credsResp, errList := client.ListCredentials(ctx, resourceGroup, name)
+	// 	if errList != nil {
+	// 		return fmt.Errorf("Error making Read request on Azure Container Registry %s for Credentials: %s", name, errList)
+	// 	}
 
-		d.Set("admin_username", credsResp.Username)
-		for _, v := range *credsResp.Passwords {
-			d.Set("admin_password", v.Value)
-			break
-		}
-	} else {
-		d.Set("admin_username", "")
-		d.Set("admin_password", "")
-	}
+	// 	d.Set("admin_username", credsResp.Username)
+	// 	for _, v := range *credsResp.Passwords {
+	// 		d.Set("admin_password", v.Value)
+	// 		break
+	// 	}
+	// } else {
+
+	// We do not want passwords in our statefiles and this api call requires more permissions than the Reader role grants
+	d.Set("admin_username", "")
+	d.Set("admin_password", "")
+
+	// }
 
 	replications, err := replicationClient.List(ctx, resourceGroup, name)
 	if err != nil {


### PR DESCRIPTION
## What

Removes `admin_username` and `admin_password` from the Container Registry schema.

## Why

We don't want to store these plaintext values nor do we request permission to do so.