### PR TITLE
[RM-5846] Profile strings can be nil

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
@@ -1409,9 +1409,13 @@ func flattenAzureRMVirtualMachineScaleSetOsProfile(d *schema.ResourceData, profi
 
 	if profile.ComputerNamePrefix != nil {
 		result["computer_name_prefix"] = *profile.ComputerNamePrefix
+	} else {
+		result["computer_name_prefix"] = ""
 	}
 	if profile.AdminUsername != nil {
 		result["admin_username"] = *profile.AdminUsername
+	} else {
+		result["admin_username"] = ""
 	}
 
 	// admin password isn't returned, so let's look it up

--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
@@ -1407,8 +1407,19 @@ func flattenAzureRmVirtualMachineScaleSetNetworkProfile(profile *compute.Virtual
 func flattenAzureRMVirtualMachineScaleSetOsProfile(d *schema.ResourceData, profile *compute.VirtualMachineScaleSetOSProfile) []interface{} {
 	result := make(map[string]interface{})
 
-	result["computer_name_prefix"] = *profile.ComputerNamePrefix
-	result["admin_username"] = *profile.AdminUsername
+	// Let's hardcode some strings. Those fields only show up in tfstate file and are not used.
+	// They should never be empty... but they are for some customers.
+	if profile.ComputerNamePrefix != nil {
+		result["computer_name_prefix"] = *profile.ComputerNamePrefix
+	} else {
+		result["computer_name_prefix"] = "vm"
+	}
+
+	if profile.AdminUsername != nil {
+		result["admin_username"] = *profile.AdminUsername
+	} else {
+		result["admin_username"] = "azureuser"
+	}
 
 	// admin password isn't returned, so let's look it up
 	if v, ok := d.GetOk("os_profile.0.admin_password"); ok {

--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
@@ -1407,18 +1407,11 @@ func flattenAzureRmVirtualMachineScaleSetNetworkProfile(profile *compute.Virtual
 func flattenAzureRMVirtualMachineScaleSetOsProfile(d *schema.ResourceData, profile *compute.VirtualMachineScaleSetOSProfile) []interface{} {
 	result := make(map[string]interface{})
 
-	// Let's hardcode some strings. Those fields only show up in tfstate file and are not used.
-	// They should never be empty... but they are for some customers.
 	if profile.ComputerNamePrefix != nil {
 		result["computer_name_prefix"] = *profile.ComputerNamePrefix
-	} else {
-		result["computer_name_prefix"] = "vm"
 	}
-
 	if profile.AdminUsername != nil {
 		result["admin_username"] = *profile.AdminUsername
-	} else {
-		result["admin_username"] = "azureuser"
 	}
 
 	// admin password isn't returned, so let's look it up


### PR DESCRIPTION
Although mandatory, some customers have these fields empty.

Tested with an empty string and all appears to be good:

```
10127   │                     "type": "azurerm_virtual_machine_scale_set",
10128   │                     "depends_on": null,
10129   │                     "primary": {
10131   │                         "attributes": {
10160   │                             "os_profile.#": "1",
10161   │                             "os_profile.0.admin_password": "",
10162   │                             "os_profile.0.admin_username": "",
10163   │                             "os_profile.0.computer_name_prefix": "",
```