### PR TITLE
[RM-5855]  Azure scan failing for `azurerm_virtual_machine_scale_set`

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
@@ -1407,28 +1407,36 @@ func flattenAzureRmVirtualMachineScaleSetNetworkProfile(profile *compute.Virtual
 func flattenAzureRMVirtualMachineScaleSetOsProfile(d *schema.ResourceData, profile *compute.VirtualMachineScaleSetOSProfile) []interface{} {
 	result := make(map[string]interface{})
 
-	if profile.ComputerNamePrefix != nil {
-		result["computer_name_prefix"] = *profile.ComputerNamePrefix
+	if profile != nil {
+
+		if profile.ComputerNamePrefix != nil {
+			result["computer_name_prefix"] = *profile.ComputerNamePrefix
+		} else {
+			result["computer_name_prefix"] = ""
+		}
+		if profile.AdminUsername != nil {
+			result["admin_username"] = *profile.AdminUsername
+		} else {
+			result["admin_username"] = ""
+		}
+
+		// admin password isn't returned, so let's look it up
+		if v, ok := d.GetOk("os_profile.0.admin_password"); ok {
+			password := v.(string)
+			result["admin_password"] = password
+		}
+
+		if profile.CustomData != nil {
+			result["custom_data"] = *profile.CustomData
+		} else {
+			// look up the current custom data
+			result["custom_data"] = utils.Base64EncodeIfNot(d.Get("os_profile.0.custom_data").(string))
+		}
 	} else {
 		result["computer_name_prefix"] = ""
-	}
-	if profile.AdminUsername != nil {
-		result["admin_username"] = *profile.AdminUsername
-	} else {
 		result["admin_username"] = ""
-	}
-
-	// admin password isn't returned, so let's look it up
-	if v, ok := d.GetOk("os_profile.0.admin_password"); ok {
-		password := v.(string)
-		result["admin_password"] = password
-	}
-
-	if profile.CustomData != nil {
-		result["custom_data"] = *profile.CustomData
-	} else {
-		// look up the current custom data
-		result["custom_data"] = utils.Base64EncodeIfNot(d.Get("os_profile.0.custom_data").(string))
+		result["admin_password"] = ""
+		result["custom_data"] = ""
 	}
 
 	return []interface{}{result}


### PR DESCRIPTION
The azure scan is failing with error:

```
panic: runtime error: invalid memory address or nil pointer dereference   
(...)                                                                                                                              
/build/src/terraform-provider-azurerm/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go:1410 +0x34                                                                            
```

Looks like all the profile is nil

```
1407   │ func flattenAzureRMVirtualMachineScaleSetOsProfile(d *schema.ResourceData, profile *compute.VirtualMachineScaleSetOSProfile) []interface{} {
1408   │     result := make(map[string]interface{})
1409   │
1410   │     if profile.ComputerNamePrefix != nil {
1411   │         result["computer_name_prefix"] = *profile.ComputerNamePrefix
1412   │     } else {
1413   │         result["computer_name_prefix"] = ""
1414   │     }
```

TEST: I forced the profile to be nil and all works as supposed.