### PR TITLE
[RM-6094] Disable CustomizeDiff for VM scale set

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
@@ -782,7 +782,9 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 			"tags": tags.Schema(),
 		},
 
-		CustomizeDiff: azureRmVirtualMachineScaleSetCustomizeDiff,
+		// RM-6094: This function is only performing validation and it's not necessary
+		// in our use-case.
+		// CustomizeDiff: azureRmVirtualMachineScaleSetCustomizeDiff,
 	}
 }
 


### PR DESCRIPTION
This PR disables the CustomizeDiff function for `azurerm_virtual_machine_scale_set` resources. It only performs validation and does not alter the diff.