### PR TITLE
[WIP] Added timeout for azurerm_snapshot

### DIFF
--- a/azurerm/internal/services/compute/data_source_snapshot.go
+++ b/azurerm/internal/services/compute/data_source_snapshot.go
@@ -1,13 +1,13 @@
 package compute
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -109,7 +109,7 @@ func dataSourceArmSnapshot() *schema.Resource {
 
 func dataSourceArmSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.SnapshotsClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := context.WithTimeout(meta.(*clients.Client).StopContext, 30*time.Second)
 	defer cancel()
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/internal/services/compute/resource_arm_snapshot.go
+++ b/azurerm/internal/services/compute/resource_arm_snapshot.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -167,7 +168,7 @@ func resourceArmSnapshotCreateUpdate(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.SnapshotsClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := context.WithTimeout(meta.(*clients.Client).StopContext, 30*time.Second)
 	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())


### PR DESCRIPTION
The azure refresh takes more than 5 minutes for `azurerm_snapshot`. This PR adds a time out of 30 secs for the `Read` resource.

This PR follows the work here: https://github.com/LuminalHQ/terraform-provider-azurerm/pull/48 