### PR TITLE
[CLOUD-1241] Allow Non-Map VM Scale Set Extension Settings

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
@@ -1563,12 +1563,16 @@ func flattenAzureRmVirtualMachineScaleSetExtensionProfile(profile *compute.Virtu
 			e["provision_after_extensions"] = schema.NewSet(schema.HashString, provisionAfterExtensions)
 
 			if settings := properties.Settings; settings != nil {
-				settingsVal := settings.(map[string]interface{})
-				settingsJson, err := structure.FlattenJsonToString(settingsVal)
-				if err != nil {
-					return nil, err
+				switch t := settings.(type) {
+				case map[string]interface{}:
+					settingsJson, err := structure.FlattenJsonToString(t)
+					if err != nil {
+						return nil, err
+					}
+					e["settings"] = settingsJson
+				default:
+					e["settings"] = t
 				}
-				e["settings"] = settingsJson
 			}
 		}
 


### PR DESCRIPTION
Though I could not reproduce this error, we encountered a situation in which a customer was causing a panic due to the settings being a string and not a map.  This fix just allows non-maps to go through - as a map is just flattened into a string anyways here.